### PR TITLE
Retain Existing Context in Templates

### DIFF
--- a/gtm/templatetags/gtm_tags.py
+++ b/gtm/templatetags/gtm_tags.py
@@ -14,9 +14,10 @@ def gtm_tag(context, google_tag_id=None):
 
     if google_tag_id is None:
         google_tag_id = getattr(settings, 'GOOGLE_TAG_ID', None)
-    return {
-        'google_tag_id': google_tag_id
-    }
+
+    context['google_tag_id'] = google_tag_id
+
+    return context
 
 
 ri("gtm/gtm.html", name='gtm', takes_context=True)(gtm_tag)


### PR DESCRIPTION
Hi @Lacrymology. 

I was wondering if you could consider this modification.

This allows people who are overriding the templates to use any context they have in the parent template. In my case, that would be adding a generated nonce to the script tag.